### PR TITLE
make table name in DB configurable

### DIFF
--- a/config/config.yml.example
+++ b/config/config.yml.example
@@ -1,6 +1,7 @@
-name: ErrataID
+name: "ErrataID"
 port: 9111
 database: "default"
+table_name: "ErrataID"
 login: "default"
 password: ""
 clickhouse_address: "clickhouse:9000"

--- a/pkg/configurator/models.go
+++ b/pkg/configurator/models.go
@@ -2,6 +2,7 @@ package configurator
 
 const defaultName = "ErrataID"
 const defaultPort = 9111
+const defaultTableName = "ErrataID"
 
 type ConfigT struct {
 	DataBase       string   `yaml:"database"`
@@ -13,6 +14,7 @@ type ConfigT struct {
 	Allowed        []string `yaml:"allowed"`
 	Name           string   `yaml:"name"`
 	Port           uint16   `yaml:"port"`
+	TableName      string   `yaml:"table_name"`
 }
 
 type InfoT struct {

--- a/pkg/configurator/utils.go
+++ b/pkg/configurator/utils.go
@@ -40,6 +40,9 @@ func parseConfig(path string) (*ConfigT, error) {
 	if config.Port == 0 {
 		config.Port = defaultPort
 	}
+	if config.TableName == "" {
+		config.TableName = defaultTableName
+	}
 	return &config, nil
 }
 


### PR DESCRIPTION
Added `table_name` configuration option support.
Updated `config.yaml` example file.